### PR TITLE
Add git + other apt dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,15 @@ LABEL repo="https://github.com/jbusecke/pangeo_pyvista_docker_image"
 
 USER root
 
-RUN apt-get update --fix-missing
-RUN apt-get install -y git groff tree vim
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq --yes > /dev/null && \
+    apt-get install --yes -qq \
+        git \
+        vim \
+        tree \
+        groff > /dev/null
 
-RUN mamba install pyproj cartopy xarray netcdf4 zarr fsspec gcsfs distributed -y
-RUN pip install geovista pyvista-xarray pykdtree --no-deps
+USER ${NB_USER}
+
+COPY environment.yml /tmp/
+
+RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,10 @@ FROM ghcr.io/pyvista/pyvista:v0.42.1
 LABEL maintainer="Julius Busecked"
 LABEL repo="https://github.com/jbusecke/pangeo_pyvista_docker_image"
 
+RUN apt-get update --fix-missing > /dev/null
+RUN apt-get install -y git groff tree vim
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+
 RUN mamba install pyproj cartopy xarray netcdf4 zarr fsspec gcsfs distributed -y
 RUN pip install geovista pyvista-xarray pykdtree --no-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/pyvista/pyvista:v0.42.1
 LABEL maintainer="Julius Busecked"
 LABEL repo="https://github.com/jbusecke/pangeo_pyvista_docker_image"
 
-RUN apt-get update --fix-missing > /dev/null
+RUN apt-get update --fix-missing
 RUN apt-get install -y git groff tree vim
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ghcr.io/pyvista/pyvista:v0.42.1
 LABEL maintainer="Julius Busecked"
 LABEL repo="https://github.com/jbusecke/pangeo_pyvista_docker_image"
 
+USER root
+
 RUN apt-get update --fix-missing
 RUN apt-get install -y git groff tree vim
 RUN apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,5 @@ USER ${NB_USER}
 COPY environment.yml /tmp/
 
 RUN mamba env update -p ${CONDA_DIR} -f /tmp/environment.yml && mamba clean -afy
+
+RUN pip install geovista pyvista-xarray pykdtree --no-deps

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,4 @@
+git
+groff
+tree
+vim

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - gcsfs
   - distributed
   - pip
+  - numpy<2

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,3 @@ dependencies:
   - gcsfs
   - distributed
   - pip
-  - pip:
-    - geovista
-    - pyvista-xarray
-    - pykdtree

--- a/environment.yml
+++ b/environment.yml
@@ -4,40 +4,16 @@ channels:
   - conda-forge
 
 dependencies:
-  - jupyter_contrib_nbextensions==0.5.1
-  # Required until https://github.com/jupyterhub/repo2docker/pull/1196 is merged
-  - jupyterhub-singleuser>=3.0,<4.0
-  # Set default python version to 3.10 - repo2docker sets it to 3.7 instead by default,
-  # which can limit us to older package versions
-  - python=3.10
-  # Everyone wants to use nbgitpuller for everything, so let's do that
-  - nbgitpuller=1.1.*
-  # Add other packages here
-  - vtk-osmesa
-  - trame
-  - ipywidgets<9.0.0
-  - geovista
-  - pyvista
-  - pyvista-xarray
+  - pyproj
+  - cartopy
   - xarray
-  - dask
-  - distributed
-  - cartopy 
-  - xarray 
-  - netcdf4 
-  - zarr 
-  - fsspec 
+  - netcdf4
+  - zarr
+  - fsspec
   - gcsfs
-  - cmocean
-  - imageio
-  - imageio-ffmpeg
-  - jupyter-server-proxy
-  - jupyterlab<5.0.0
-  - meshio
-  - trame>=2.5.2
-  - trame-vtk>=2.5.8
-  - trame-vuetify>=2.3.1
-  - trimesh
-  - intake
-  - intake-esm 
-  - intake-xarray
+  - distributed
+  - pip
+  - pip:
+    - geovista
+    - pyvista-xarray
+    - pykdtree


### PR DESCRIPTION
This image does not have git installed. I am trying to reproduce what the [pangeo-docker-image](https://github.com/pangeo-data/pangeo-docker-images/blob/7edf75add75f2f4279e3a7e145f0721768cb04fb/base-image/Dockerfile#L96) does. Since we are using repo2docker I think adding an `apt.txt` with these requirements should suffice?